### PR TITLE
Add config option for perspective direction

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx2G
 # boilerplate
 modId = pmr
 modName = PerspectiveModRedux
-version = 0.0.4
+version = 0.0.5
 acceptedMinecraftVersions = [1.8.9]
 minecraftVersion = 1.8.9
 forgeVersion = 11.15.1.2318-1.8.9

--- a/src/main/java/pm/c7/pmr/PerspectiveMod.java
+++ b/src/main/java/pm/c7/pmr/PerspectiveMod.java
@@ -145,7 +145,7 @@ public class PerspectiveMod
 
     public static void saveConfig() {
         holdToUse = config.getBoolean("Hold To Use", "main", false, null);
-        lookForwards = config.getBoolean("Look Forwards", "main", false, null);
+        lookForwards = config.getBoolean("Look Forwards", "main", true, null);
         config.save();
     }
 

--- a/src/main/java/pm/c7/pmr/PerspectiveMod.java
+++ b/src/main/java/pm/c7/pmr/PerspectiveMod.java
@@ -41,6 +41,7 @@ public class PerspectiveMod
     private boolean showConfig = false;
 
     private static boolean holdToUse = false;
+    private static boolean lookForwards = false;
 
     public boolean perspectiveEnabled = false;
     public float cameraPitch;
@@ -109,7 +110,11 @@ public class PerspectiveMod
                     this.held = true;
 
                     this.cameraPitch = this.client.thePlayer.rotationPitch;
-                    this.cameraYaw = this.client.thePlayer.rotationYaw + 180.0F;
+                    if(lookForwards) {
+                        this.cameraYaw = this.client.thePlayer.rotationYaw - 180.0F;
+                    } else {
+                        this.cameraYaw = this.client.thePlayer.rotationYaw;
+                    }
 
                     this.client.gameSettings.thirdPersonView = 1;
                 }
@@ -118,7 +123,11 @@ public class PerspectiveMod
                     this.perspectiveEnabled = !this.perspectiveEnabled;
 
                     this.cameraPitch = this.client.thePlayer.rotationPitch;
-                    this.cameraYaw = this.client.thePlayer.rotationYaw;
+                    if(lookForwards) {
+                        this.cameraYaw = this.client.thePlayer.rotationYaw - 180.0F;
+                    } else {
+                        this.cameraYaw = this.client.thePlayer.rotationYaw;
+                    }
 
                     this.client.gameSettings.thirdPersonView = this.perspectiveEnabled ? 1 : 0;
                 }
@@ -136,7 +145,7 @@ public class PerspectiveMod
 
     public static void saveConfig() {
         holdToUse = config.getBoolean("Hold To Use", "main", false, null);
-
+        lookForwards = config.getBoolean("Look Forwards", "main", false, null);
         config.save();
     }
 


### PR DESCRIPTION
This adds a config option where you can face forward by default instead. Some people prefer this direction instead of reverse

config:
![image](https://user-images.githubusercontent.com/45705145/125898354-dba613ec-1c1f-4ac6-a2b6-a807fdcbc863.png)

default direction when 'look forwards' is true:
![image](https://user-images.githubusercontent.com/45705145/125898394-1dd89bcc-224b-4159-96da-7e2d52a7f32a.png)

I also updated plugin version from 0.0.4 to 0.0.5
1.17 fabric port coming soon™